### PR TITLE
Replace sync file read with async in route

### DIFF
--- a/routes/home.js
+++ b/routes/home.js
@@ -3,15 +3,26 @@ const fs = require('fs');
 const path = require('path');
 const router = express.Router();
 
-router.get('/',(req,res,next) => {
+router.get('/', (req, res, next) => {
+    const pwd = path.join(__dirname, '../public/ress/mountedRess/me.json');
 
-    pwd =  path.join(__dirname,'../public/ress/mountedRess/me.json');
-    var obj = JSON.parse(fs.readFileSync(pwd, 'utf8'));
+    fs.readFile(pwd, 'utf8', (err, data) => {
+        if (err) {
+            return next(err);
+        }
 
-    const viewsData = {
-        data: obj
-    };
-    res.render('cv',viewsData);
+        let obj;
+        try {
+            obj = JSON.parse(data);
+        } catch (parseErr) {
+            return next(parseErr);
+        }
+
+        const viewsData = {
+            data: obj
+        };
+        res.render('cv', viewsData);
+    });
 });
 
 module.exports = router


### PR DESCRIPTION
## Summary
- use `fs.readFile` instead of `fs.readFileSync` in `routes/home.js`
- add error handling for file read and JSON parse

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684fbf91c72c832aab826bea54569967